### PR TITLE
Attachment content validation set to any as per nodemailer documumentation

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -53,7 +53,7 @@ const validateMailOptionsSchema = Joi.object().keys({
     attachments: Joi.array().items(
         Joi.object().keys({
             filename: Joi.string(),
-            content: Joi.string(),
+            content: Joi.any(),
             path: Joi.string(),
             href: Joi.string(),
             contentType: Joi.string(),


### PR DESCRIPTION
This fixes an issue with the attachments, as per the nodemailer's documentation [here](https://nodemailer.com/message/attachments/), the content could be any of String, Buffer or Stream